### PR TITLE
Change greedy regex to a recursive

### DIFF
--- a/bin/mdextract
+++ b/bin/mdextract
@@ -75,7 +75,7 @@ function readStdin (fn) {
 }
 
 function updateFile (data) {
-  data = data.replace(/(<!-- include: (.*?) -->)[\s\S]*(<!-- \/include(?:: .*?)? -->)/g, function (_, open, fname, close) {
+  data = data.replace(/(<!-- include: (.*?) -->)[\s\S]*(<!-- \/include(?:: (\2))? -->)/g, function (_, open, fname, close) {
     var doc = mdextract(fs.readFileSync(fname, 'utf-8'));
     return [
       open,


### PR DESCRIPTION
So that multiple includes into one file is now possible.

e.g.
```
## Group 1
<!-- include: lib/group_1.js -->
<!-- /include: lib/group_1 -->

## Group 2
<!-- include: lib/group_2 -->
<!-- /include: lib/group_2 -->

## Group 3
<!-- include: lib/group_3 -->
<!-- /include: lib/group_3 -->
```